### PR TITLE
added support for linux-5.15.167

### DIFF
--- a/package/kernel/mac80211/patches/subsys/999-mac80211-NSS-support.patch
+++ b/package/kernel/mac80211/patches/subsys/999-mac80211-NSS-support.patch
@@ -236,7 +236,7 @@
  /*
   * monitor mode reception
   *
-@@ -2635,10 +2689,16 @@ static void ieee80211_deliver_skb_to_loc
+@@ -2611,6 +2611,11 @@
  			ether_addr_copy(ehdr->h_dest, sdata->vif.addr);
  
  		/* deliver to local stack */
@@ -246,7 +246,10 @@
 +		}
 +#else
  		if (rx->list)
+ #if LINUX_VERSION_IS_GEQ(4,19,0)
  			list_add_tail(&skb->list, rx->list);
+@@ -2619,6 +2624,7 @@
+ #endif
  		else
  			netif_receive_skb(skb);
 +#endif

--- a/target/linux/ipq806x/patches-5.15/999-300-qca-mcs-support.patch
+++ b/target/linux/ipq806x/patches-5.15/999-300-qca-mcs-support.patch
@@ -42,7 +42,7 @@
  int nbp_backup_change(struct net_bridge_port *p, struct net_device *backup_dev);
  
  /* br_input.c */
-+int br_pass_frame_up(struct sk_buff *skb); /* QCA qca-mcs support */
++int br_pass_frame_up(struct sk_buff *skb, bool promisc); /* QCA qca-mcs support */
  int br_handle_frame_finish(struct net *net, struct sock *sk, struct sk_buff *skb);
  rx_handler_func_t *br_get_rx_handler(const struct net_device *dev);
  
@@ -124,8 +124,8 @@
  	return netif_receive_skb(skb);
  }
  
--static int br_pass_frame_up(struct sk_buff *skb)
-+int br_pass_frame_up(struct sk_buff *skb)
+-static int br_pass_frame_up(struct sk_buff *skb, bool promisc)
++int br_pass_frame_up(struct sk_buff *skb, bool promisc)
  {
  	struct net_device *indev, *brdev = BR_INPUT_SKB_CB(skb)->brdev;
  	struct net_bridge *br = netdev_priv(brdev);


### PR DESCRIPTION
linux-5.15.167 (for 23.05.5) introduces additional changes that break some of the NSS patches.

- [999-mac80211-NSS-support.patch](https://github.com/ACwifidude/openwrt/compare/openwrt-23.05-nss-qsdk11...ingamedeo:openwrt:openwrt-23.05-nss-qsdk11?expand=1#diff-17bba47f49d07454d36913d321aee2743dfe7449b82bcb2ccea466ac66b23e2d) needs to be changed to support the newly included check for older kernels in rx.c (mac80211)
- [999-300-qca-mcs-support.patch](https://github.com/ACwifidude/openwrt/compare/openwrt-23.05-nss-qsdk11...ingamedeo:openwrt:openwrt-23.05-nss-qsdk11?expand=1#diff-7d58107848f625b96f403156fdabaeb73d145212505d8008bd80162352fc16bf) needs to support the new br_pass_frame_up signature that requires that an extra argument (promisc) to be passed in.

This PR should be merged together with the PR in nss-packages for the same purpose.

